### PR TITLE
feat: Common용 JwtAuthenticationFilterForCommon, CustomAuthentication,…

### DIFF
--- a/application/user-service/build.gradle
+++ b/application/user-service/build.gradle
@@ -4,6 +4,7 @@ jar { enabled = false }
 
 
 dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     // jwt추가
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
@@ -12,8 +13,10 @@ dependencies {
 
     // 스프링 시큐리티 (패스워드 인코더)
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // validation 의존성
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // postgresql
     runtimeOnly 'org.postgresql:postgresql'
 
@@ -22,6 +25,7 @@ dependencies {
     //아래는 주창님이 추가하신 내역들 postgresql은 중복으로 삭제
     implementation project(":component:exception")
     implementation project(":component:jpa")
+
     // docker compose support
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 }

--- a/application/user-service/src/main/java/com/fortickets/userservice/UserServiceApplication.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/UserServiceApplication.java
@@ -2,9 +2,11 @@ package com.fortickets.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @SpringBootApplication
+@EnableFeignClients // FeignClient 활성화
 public class UserServiceApplication {
 
     public static void main(String[] args) {

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/FeignClientConfig.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/FeignClientConfig.java
@@ -1,0 +1,47 @@
+package com.fortickets.userservice.application;
+
+import org.springframework.security.core.GrantedAuthority;
+import com.fortickets.userservice.application.security.CustomAuthentication;
+import feign.RequestInterceptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FeignClientConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> {
+            // SecurityContext에서 인증 정보 가져오기
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication instanceof CustomAuthentication customAuth) {
+                // 사용자 정보 추출
+                Long userId = customAuth.getUserId();
+                String email = customAuth.getEmail();
+                String role = authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .findFirst()
+                    .orElse(null); // 또는 필요한 방식으로 권한을 설정
+
+                // 로그 추가
+                log.info("Intercepting request with headers: X-User-Id={}, X-Email={}, X-Role={}", userId, email, role);
+
+                // 추가적인 사용자 정보 헤더에 추가
+                if (userId != null) {
+                    template.header("X-User-Id", String.valueOf(userId));
+                }
+                if (email != null) {
+                    template.header("X-Email", email);
+                }
+                if (role != null) {
+                    template.header("X-Role", role);
+                }
+            }
+        };
+    }
+}

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/OrderClient.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/OrderClient.java
@@ -1,0 +1,12 @@
+package com.fortickets.userservice.application;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "order-service", url = "http://localhost:12041") // 주문 서비스의 URL을 설정합니다.
+public interface OrderClient {
+
+//    @GetMapping("/booking/hello")
+//    String hello();
+
+}

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/security/CustomAuthentication.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/security/CustomAuthentication.java
@@ -1,0 +1,18 @@
+package com.fortickets.userservice.application.security;
+
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class CustomAuthentication extends UsernamePasswordAuthenticationToken {
+    private final Long userId;
+    private final String email;
+
+    public CustomAuthentication(Long userId, String email, Collection<? extends GrantedAuthority> authorities) {
+        super(userId, null, authorities);
+        this.userId = userId;
+        this.email = email;
+    }
+}

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/security/JwtAuthenticationFilterForCommon.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/security/JwtAuthenticationFilterForCommon.java
@@ -1,0 +1,101 @@
+//package com.fortickets.userservice.application.security;
+//
+//import io.jsonwebtoken.Claims;
+//import io.jsonwebtoken.Jwts;
+//import io.jsonwebtoken.security.Keys;
+//import jakarta.annotation.PostConstruct;
+//import jakarta.servlet.FilterChain;
+//import jakarta.servlet.ServletException;
+//import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletResponse;
+//import java.io.IOException;
+//import java.nio.charset.StandardCharsets;
+//import java.util.Base64;
+//import javax.crypto.SecretKey;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.authority.AuthorityUtils;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//import org.springframework.stereotype.Component;
+//import org.springframework.util.StringUtils;
+//import org.springframework.web.filter.OncePerRequestFilter;
+//
+//@Slf4j(topic = "Common용")
+//@Component
+//@RequiredArgsConstructor
+//public class JwtAuthenticationFilterForCommon extends OncePerRequestFilter {
+//
+//    @Value("${service.jwt.secret-key}") // Base64 Encode 한 SecretKey
+//    private String secretKey;
+//    private SecretKey key;
+//
+//    @PostConstruct
+//    public void init() {
+//        byte[] bytes = Base64.getDecoder().decode(secretKey);
+//        key = Keys.hmacShaKeyFor(bytes);
+//    }
+//
+//    @Override
+//    protected void doFilterInternal(HttpServletRequest request,
+//        HttpServletResponse response,
+//        FilterChain filterChain) throws ServletException, IOException {
+//
+//        // 필터가 처음 시작되면 SecretKey 초기화
+//        if (key == null) {
+//            byte[] decodedKey = Base64.getDecoder().decode(secretKey.getBytes(StandardCharsets.UTF_8));
+//            key = Keys.hmacShaKeyFor(decodedKey);
+//        }
+//
+//        // 헤더에서 토큰 추출
+//        String token = getJwtFromHeader(request);
+//
+//        if (token != null) {
+//            // 토큰에서 사용자 정보 추출
+//            Claims claims = getClaimsFromToken(token);
+//            Long userId = claims.get("userId", Long.class);
+//            String email = claims.get("email", String.class);
+//            String role = claims.get("role", String.class);
+//
+//            // 추출 확인 로그
+//            log.info("Extracted from token: userId={}, email={}, role={}", userId, email, role);
+//
+//            // 사용자 정보로 Authentication 객체 생성
+//            Authentication authentication = createAuthentication(userId, email, role);
+//
+//            // SecurityContext에 인증 정보 저장
+//            SecurityContextHolder.getContext().setAuthentication(authentication);
+//        }
+//        // 다음 필터로 요청 전달
+//        filterChain.doFilter(request, response);
+//    }
+//
+//    // ?
+//
+//    // JWT 토큰을 요청 헤더에서 가져오는 메서드
+//    private String getJwtFromHeader(HttpServletRequest request) {
+//        String bearerToken = request.getHeader("Authorization");
+//        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+//            return bearerToken.substring(7); // "Bearer " 이후의 실제 토큰 값 추출
+//        }
+//        return null;
+//    }
+//
+//    // 토큰에서 Claims 정보 추출
+//    private Claims getClaimsFromToken(String token) {
+//        return Jwts.parserBuilder()
+//            .setSigningKey(key)
+//            .build()
+//            .parseClaimsJws(token)
+//            .getBody();
+//    }
+//
+//    // Authentication 객체 생성 (사용자 정보와 권한 설정)
+//    private Authentication createAuthentication(Long userId, String email, String role) {
+//        // 권한 설정
+//        var authorities = AuthorityUtils.createAuthorityList(role);
+//        // Authentication 객체 생성
+//        return new CustomAuthentication(userId, email, authorities);
+//    }
+//}

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/security/JwtAuthenticationFilterForUserService.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/security/JwtAuthenticationFilterForUserService.java
@@ -26,7 +26,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j(topic = "JWT에서 정보 추출")
-public class JwtAuthorizationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilterForUserService extends OncePerRequestFilter {
 
     @Value("${service.jwt.secret-key}") // Base64 Encode 한 SecretKey
     private String secretKey;
@@ -39,7 +39,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public JwtAuthorizationFilter(UserDetailsServiceImpl userDetailsService) {
+    public JwtAuthenticationFilterForUserService(UserDetailsServiceImpl userDetailsService) {
         this.userDetailsService = userDetailsService;
     }
 
@@ -67,16 +67,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
                 // 역할 추출 및 접두어 추가
                 String role = claims.get(JwtUtil.USER_ROLE, String.class); // USER_ROLE을 사용하여 역할 추출
-                log.info("Extracted Role from Claims: {}", role); // 역할을 로그로 출력
-                if (role != null && !role.isEmpty()) {
-                    role = "ROLE_" + role; // 접두어 추가
-                } else {
+                if (role == null && role.isEmpty()) {
                     log.error("Role is null or empty");
                     res.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 상태 코드 설정
                     return;
                 }
 
-                // 인증 설정
+//                 인증 설정 여기서 헤더에 넣는 작업 추가
                 setAuthentication(email, role); // 역할을 포함하여 인증 설정
 
             } catch (Exception e) {

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/security/JwtUtil.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/security/JwtUtil.java
@@ -51,7 +51,7 @@ public class JwtUtil {
         Date date = new Date();
         String authority  = "ROLE_" + role; // 역할에 접두어 추가
         // JWT Claims 확인 로그 추가
-        log.info("JWT Claims - userId: {}, email: {}, role: {}", userId, email, role);
+        log.info("JWT Claims - userId: {}, email: {}, role: {}", userId, email, authority);
 
         return BEARER_PREFIX +
             Jwts.builder()

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/service/AuthService.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/service/AuthService.java
@@ -2,6 +2,7 @@ package com.fortickets.userservice.application.service;
 
 import com.fortickets.common.ErrorCase;
 import com.fortickets.exception.GlobalException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import com.fortickets.userservice.application.dto.requset.LoginReq;
 import com.fortickets.userservice.application.dto.requset.SignUpReq;
@@ -20,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -116,8 +118,13 @@ public class AuthService {
             String username = userDetails.getUsername(); // 메서드는 getUsername 이지만 return값은 email 입니다.
             UserRoleEnum role = userDetails.getUser().getRole();
 
+            // JWT 토큰 생성 - 로그를위해 임시
+            String jwtToken = jwtUtil.createAccessToken(userId, username, role);
+
+            log.info("Issued JWT Token: {}", jwtToken); // 발급된 JWT 로그 추가
             // JWT 토큰 생성
-            return jwtUtil.createAccessToken(userId, username, role);
+//            return jwtUtil.createAccessToken(userId, username, role);
+            return jwtToken;
         } catch (AuthenticationException e) {
             throw new GlobalException(ErrorCase.INVALID_EMAIL_OR_PASSWORD);
         }

--- a/application/user-service/src/main/java/com/fortickets/userservice/application/service/UserService.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/application/service/UserService.java
@@ -2,6 +2,7 @@ package com.fortickets.userservice.application.service;
 
 import com.fortickets.common.ErrorCase;
 import com.fortickets.exception.GlobalException;
+import com.fortickets.userservice.application.OrderClient;
 import com.fortickets.userservice.application.dto.requset.UpdateUserReq;
 import com.fortickets.userservice.application.dto.response.GetUserRes;
 import com.fortickets.userservice.application.mapper.UserMapper;
@@ -17,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @AllArgsConstructor
 public class UserService {
+
+//    private final OrderClient orderClient;
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder; // PasswordEncoder 추가
@@ -57,4 +60,9 @@ public class UserService {
         // 업데이트 된 정보를 저장
         userRepository.save(user);
     }
+
+    // feignClient test
+//    public String callOrderHello() {
+//        return orderClient.hello(); // OrderClient의 hello 메서드 호출
+//    }
 }

--- a/application/user-service/src/main/java/com/fortickets/userservice/presentation/controller/AuthController.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/presentation/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.fortickets.userservice.presentation.controller;
 
+import static com.fortickets.common.CommonResponse.getSuccessRes;
 import com.fortickets.common.CommonResponse;
+import com.fortickets.common.CommonResponse.CommonEmptyRes;
 import com.fortickets.userservice.application.dto.requset.LoginReq;
 import com.fortickets.userservice.application.dto.requset.SignUpReq;
 import com.fortickets.userservice.application.security.JwtUtil;
@@ -24,25 +26,19 @@ public class AuthController {
 
     // 회원가입
     @PostMapping("/sign-up")
-    public CommonResponse<String> signUp(@Valid @RequestBody SignUpReq req) {
+    public CommonResponse<CommonEmptyRes> signUp(@Valid @RequestBody SignUpReq req) {
         authService.signUp(req);
-        return CommonResponse.success("회원가입을 성공하였습니다.");
+        return CommonResponse.success();
+//        return CommonResponse.success("회원가입을 성공하였습니다.");
     }
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<CommonResponse<String>> login(@RequestBody LoginReq req) {
+    public ResponseEntity<CommonResponse<CommonEmptyRes>> login(@RequestBody LoginReq req) {
         String token = authService.login(req);
 
         return ResponseEntity.ok()
             .header(JwtUtil.AUTHORIZATION_HEADER, token) // Authorization 헤더에 토큰 추가
-            .body(CommonResponse.success("로그인을 성공하였습니다.")); // 성공 메시지 반환
+            .body(CommonResponse.success()); // 성공 메시지 반환
     }
-
-    // 로그아웃
-//    @PostMapping("/logout")
-//    public ResponseEntity<String> logout(String accessToken) {
-//        authService.logout(accessToken);
-//        return ResponseEntity.ok("로그아웃을 성공하였습니다.");
-//    }
 }

--- a/application/user-service/src/main/java/com/fortickets/userservice/presentation/controller/UserController.java
+++ b/application/user-service/src/main/java/com/fortickets/userservice/presentation/controller/UserController.java
@@ -1,16 +1,22 @@
 package com.fortickets.userservice.presentation.controller;
 
 import com.fortickets.common.CommonResponse;
+import com.fortickets.common.CommonResponse.CommonEmptyRes;
 import com.fortickets.userservice.application.dto.requset.UpdateUserReq;
 import com.fortickets.userservice.application.dto.response.GetUserRes;
+import com.fortickets.userservice.application.security.CustomAuthentication;
 import com.fortickets.userservice.application.security.UserDetailsImpl;
 import com.fortickets.userservice.application.service.UserService;
 import jakarta.validation.Valid;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,10 +49,42 @@ public class UserController {
 
     // 사용자 정보 수정
     @PutMapping
-    public CommonResponse<String> updateUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails,
+    public CommonResponse<CommonEmptyRes> updateUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails,
         @Valid  @RequestBody UpdateUserReq req) {
         Long userId = userDetails.getUser().getUserId();
         userService.updateUserInfo(userId, req);
-        return CommonResponse.success("회원정보 수정을 성공하였습니다.");
+        return CommonResponse.success();
     }
+
+    // Common용 JwtAutenticationFilter 테스트를 위한 코드입니다
+    @PreAuthorize("hasRole('MANAGER')") // 역할에 ROLE_을 추가
+    @GetMapping("/test")
+    public CommonResponse<Object> getAuthenticatedUserInfo() {
+        // 현재 인증된 사용자의 Authentication 객체를 가져옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // CustomAuthentication으로 형변환
+        CustomAuthentication customAuth = (CustomAuthentication) authentication;
+
+        // 사용자 정보 (userId, email 등)
+        Long userId = customAuth.getUserId();
+        String email = customAuth.getEmail();
+
+        // 권한 정보 (role 등)
+        Object authority = authentication.getAuthorities();
+
+        // 사용자 정보와 권한 정보를 함께 리턴
+        Map<String, Object> response = new HashMap<>();
+        response.put("email", email);
+        response.put("userId", userId);
+        response.put("roles", authority);
+
+        return CommonResponse.success(response);
+    }
+
+    // feignClient test
+//    @GetMapping("/test/hello")
+//    public String testHello() {
+//        return userService.callOrderHello(); // UserService의 메서드를 통해 호출
+//    }
 }

--- a/component/security/src/main/java/com/fortickets/security/CustomAuthentication.java
+++ b/component/security/src/main/java/com/fortickets/security/CustomAuthentication.java
@@ -1,0 +1,18 @@
+package com.fortickets.security;
+
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class CustomAuthentication extends UsernamePasswordAuthenticationToken {
+    private final Long userId;
+    private final String email;
+
+    public CustomAuthentication(Long userId, String email, Collection<? extends GrantedAuthority> authorities) {
+        super(userId, null, authorities);
+        this.userId = userId;
+        this.email = email;
+    }
+}

--- a/component/security/src/main/java/com/fortickets/security/FeignClientConfig.java
+++ b/component/security/src/main/java/com/fortickets/security/FeignClientConfig.java
@@ -1,0 +1,46 @@
+package com.fortickets.security;
+
+import feign.RequestInterceptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FeignClientConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> {
+            // SecurityContext에서 인증 정보 가져오기
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication instanceof CustomAuthentication customAuth) {
+                // 사용자 정보 추출
+                Long userId = customAuth.getUserId();
+                String email = customAuth.getEmail();
+                String role = authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .findFirst()
+                    .orElse(null); // 또는 필요한 방식으로 권한을 설정
+
+                // 로그 추가
+                log.info("Intercepting request with headers: X-User-Id={}, X-Email={}, X-Role={}", userId, email, role);
+
+                // 추가적인 사용자 정보 헤더에 추가
+                if (userId != null) {
+                    template.header("X-User-Id", String.valueOf(userId));
+                }
+                if (email != null) {
+                    template.header("X-Email", email);
+                }
+                if (role != null) {
+                    template.header("X-Role", role);
+                }
+            }
+        };
+    }
+}

--- a/component/security/src/main/java/com/fortickets/security/JwtAuthenticationFilterForCommon.java
+++ b/component/security/src/main/java/com/fortickets/security/JwtAuthenticationFilterForCommon.java
@@ -1,0 +1,101 @@
+package com.fortickets.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j(topic = "Common용")
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilterForCommon extends OncePerRequestFilter {
+
+    @Value("${service.jwt.secret-key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        // 필터가 처음 시작되면 SecretKey 초기화
+        if (key == null) {
+            byte[] decodedKey = Base64.getDecoder().decode(secretKey.getBytes(StandardCharsets.UTF_8));
+            key = Keys.hmacShaKeyFor(decodedKey);
+        }
+
+        // 헤더에서 토큰 추출
+        String token = getJwtFromHeader(request);
+
+        if (token != null) {
+            // 토큰에서 사용자 정보 추출
+            Claims claims = getClaimsFromToken(token);
+            Long userId = claims.get("userId", Long.class);
+            String email = claims.get("email", String.class);
+            String role = claims.get("role", String.class);
+
+            // 추출 확인 로그
+            log.info("Extracted from token: userId={}, email={}, role={}", userId, email, role);
+
+            // 사용자 정보로 Authentication 객체 생성
+            Authentication authentication = createAuthentication(userId, email, role);
+
+            // SecurityContext에 인증 정보 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    // ?
+
+    // JWT 토큰을 요청 헤더에서 가져오는 메서드
+    private String getJwtFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 이후의 실제 토큰 값 추출
+        }
+        return null;
+    }
+
+    // 토큰에서 Claims 정보 추출
+    private Claims getClaimsFromToken(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+    }
+
+    // Authentication 객체 생성 (사용자 정보와 권한 설정)
+    private Authentication createAuthentication(Long userId, String email, String role) {
+        // 권한 설정
+        var authorities = AuthorityUtils.createAuthorityList(role);
+        // Authentication 객체 생성
+        return new CustomAuthentication(userId, email, authorities);
+    }
+}

--- a/component/security/src/main/java/com/fortickets/security/SecurityConfig.java
+++ b/component/security/src/main/java/com/fortickets/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.fortickets.userservice.application.security;
+package com.fortickets.security;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,8 +23,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final UserDetailsServiceImpl userDetailsServiceImpl;
-
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -36,14 +34,9 @@ public class SecurityConfig {
         return configuration.getAuthenticationManager();
     }
 
-//    @Bean
-//    public JwtAuthenticationFilterForCommon jwtAuthenticationFilterForCommon() {
-//        return new JwtAuthenticationFilterForCommon();
-//    }
-
     @Bean
-    public JwtAuthenticationFilterForUserService jwtAuthorizationFilterForUserService() {
-        return new JwtAuthenticationFilterForUserService(userDetailsServiceImpl); // 필드 사용
+    public JwtAuthenticationFilterForCommon jwtAuthenticationFilterForCommon() {
+        return new JwtAuthenticationFilterForCommon();
     }
 
     @Bean
@@ -67,8 +60,7 @@ public class SecurityConfig {
         );
 
         // 필터 관리
-//        http.addFilterBefore(jwtAuthenticationFilterForCommon(), UsernamePasswordAuthenticationFilter.class);
-        http.addFilterBefore(jwtAuthorizationFilterForUserService(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilterForCommon(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,6 @@ include 'application:eureka'
 include 'component:jpa'
 include 'component:exception'
 include 'component:common'
+include 'component:security'
+findProject(':component:security')?.name = 'security'
 


### PR DESCRIPTION
… SecurityConfig, FeignClientConfig 구현

refactor: api 성공시 status 200이 있는데 성공 메시지를 출력할 필요 없을것 같다는 팀원들의 의견에 따라 출력해주던 메시지 삭제

## #️⃣연관된 이슈

> #8 

## 📝작업 내용

> 요청해주신 CommonResponse 수정, 클라이언트 요청 헤더에서 JWT 토큰을 추출하고 인증객체를 생성하는 필터 구현,
인증객체에 사용자 정보를 담기위해 커스텀인증객체 생성, 공용 securityconfig 설정(경로에 따라 공용이 아닌 각자 서비스에서 관리해야 할 수 있음),  페인클라이언트 사용시 헤더에 사용자 정보를 담기위한 FeignClientConfig 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

