### PR TITLE
[#54] feat(Redis): Redis Cluster 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,10 @@ db/
 **/application-credentials.yml
 
 ### redis ###
-redis_data/
+redis_data
+redis_data_master1/
+redis_data_master2/
+redis_data_master3/
+redis_data_slave1/
+redis_data_slave2/
+redis_data_slave3/

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ subprojects {
 
     // 모든 서브 모듈에서 사용될 공통 의존성들을 추가함
     dependencies {
-        // redis
-        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
         // zipkin 관련 의존성 추가
         implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
         implementation 'io.micrometer:micrometer-tracing-bridge-brave'
@@ -54,11 +51,6 @@ subprojects {
         // Test
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-        // module
-        if (project.name != 'redis' && project.name != 'common') {
-            implementation project(":component:redis")
-        }
 
         if (project.name != 'gateway-service') {
             // spring web mvc
@@ -77,6 +69,7 @@ subprojects {
             } else {
                 //eureka client
                 implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+                implementation project(':component:redis')
             }
             //openFeign
             implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/component/redis/build.gradle
+++ b/component/redis/build.gradle
@@ -12,6 +12,9 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    // redis
+    api('org.springframework.boot:spring-boot-starter-data-redis')
 }
 
 test {

--- a/component/redis/src/main/java/com/fortickets/redis/config/RedisConfig.java
+++ b/component/redis/src/main/java/com/fortickets/redis/config/RedisConfig.java
@@ -1,0 +1,5 @@
+package com.fortickets.redis.config;
+
+public class RedisConfig {
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,80 @@ services:
   zipkin:
     image: openzipkin/zipkin
     ports:
-      - "9411:9411" # Zipkin UI에 접근할 포트
+      - "9411:9411" # Zipkin UI 접근 포트
 
-  redis-stack:
-    image: redis/redis-stack
-    container_name: redis-stack-compose
-    restart: always
-    environment:
-      REDIS_ARGS: "--requirepass systempass"
-    volumes:
-      - ./redis_data:/data
+  # Redis 마스터 노드 1
+  redis-master1:
+    image: redis:7
+    container_name: redis-master1
+    command: ["redis-server", "--cluster-enabled", "yes", "--appendonly", "yes", "--requirepass", "systempass"]
     ports:
-      - 6379:6379
-      - 8001:8001
-#    network_mode: host
+      - "6379:6379"
+    volumes:
+      - ./redis_data_master1:/data
+    networks:
+      - redis-cluster
+
+  # Redis 마스터 노드 2
+  redis-master2:
+    image: redis:7
+    container_name: redis-master2
+    command: ["redis-server", "--cluster-enabled", "yes", "--appendonly", "yes", "--requirepass", "systempass"]
+    ports:
+      - "6380:6379"
+    volumes:
+      - ./redis_data_master2:/data
+    networks:
+      - redis-cluster
+
+  # Redis 마스터 노드 3
+  redis-master3:
+    image: redis:7
+    container_name: redis-master3
+    command: ["redis-server", "--cluster-enabled", "yes", "--appendonly", "yes", "--requirepass", "systempass"]
+    ports:
+      - "6381:6379"
+    volumes:
+      - ./redis_data_master3:/data
+    networks:
+      - redis-cluster
+
+  # Redis 슬레이브 노드 1
+  redis-slave1:
+    image: redis:7
+    container_name: redis-slave1
+    command: ["redis-server", "--cluster-enabled", "yes", "--appendonly", "yes", "--requirepass", "systempass", "--masterauth", "systempass"]
+    ports:
+      - "6382:6379"
+    volumes:
+      - ./redis_data_slave1:/data
+    networks:
+      - redis-cluster
+
+  # Redis 슬레이브 노드 2
+  redis-slave2:
+    image: redis:7
+    container_name: redis-slave2
+    command: ["redis-server", "--cluster-enabled", "yes", "--appendonly", "yes", "--requirepass", "systempass", "--masterauth", "systempass"]
+    ports:
+      - "6383:6379"
+    volumes:
+      - ./redis_data_slave2:/data
+    networks:
+      - redis-cluster
+
+  # Redis 슬레이브 노드 3
+  redis-slave3:
+    image: redis:7
+    container_name: redis-slave3
+    command: ["redis-server", "--cluster-enabled", "yes", "--appendonly", "yes", "--requirepass", "systempass", "--masterauth", "systempass"]
+    ports:
+      - "6384:6379"
+    volumes:
+      - ./redis_data_slave3:/data
+    networks:
+      - redis-cluster
+
+networks:
+  redis-cluster:
+    driver: bridge


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #54 

## 📝작업 내용

- Redis 단일 노드를 Cluster로 세팅

- **pull 받으시면 해야될 것**
1. 전에 생성되었던 Redis 컨테이너를 삭제한다.
2. 다시 docker compose up 하여 컨테이너 6개를 실행시킨다.(master 3개, slave 3개)
![스크린샷 2024-10-08 오후 12 34 47](https://github.com/user-attachments/assets/f0e5eef0-aad9-4020-a3cd-4be82f1c40ee)
3. 이 노드들을 하나의 클러스터 네트워크로 연결시킨다.(해당 내용에 대해서는 **팀 노션 공유자료**에 추가하겠습니다.)
4. 본인의 입맛대로 사용한다.(Redis를 사용하는데에 단일 노드일 때와 마찬가지로 사용하시면 됩니다.)

## 💬리뷰 요구사항(선택)
