### PR TITLE
#74 feat(order) : 공연 서비스 Cache 적용

### DIFF
--- a/application/concert-service/src/main/java/com/fortickets/concertservice/application/dto/response/GetConcertRes.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/application/dto/response/GetConcertRes.java
@@ -1,18 +1,24 @@
 package com.fortickets.concertservice.application.dto.response;
 
-import com.fortickets.concertservice.domain.entity.Schedule;
 import java.time.LocalDate;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record GetConcertRes(
-    Long id,
-    String concertName,
-    String concertImage,
-    int runtime,
-    Long price,
-    LocalDate startDate,
-    LocalDate endDate,
-    List<GetScheduleRes> schedules
-) {
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetConcertRes {
 
+    private Long id;
+    private String concertName;
+    private String concertImage;
+    private int runtime;
+    private Long price;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<GetScheduleRes> schedules;
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/application/dto/response/GetConcertsRes.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/application/dto/response/GetConcertsRes.java
@@ -1,16 +1,23 @@
 package com.fortickets.concertservice.application.dto.response;
 
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record GetConcertsRes(
-    Long id,
-    Long userId,
-    String concertName,
-    String concertImage,
-    int runtime,
-    LocalDate startDate,
-    LocalDate endDate,
-    Long price
-) {
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetConcertsRes {
+    private Long id;
+    private Long userId;
+    private String concertName;
+    private String concertImage;
+    private int runtime;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Long price;
 
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/infrastructure/config/ComponentConfig.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/infrastructure/config/ComponentConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
     "com.fortickets.common.exception",
     "com.fortickets.common.jpa",
     "com.fortickets.common.security",
+    "com.fortickets.redis"
 })
 public class ComponentConfig {
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/presentation/ConcertController.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/presentation/ConcertController.java
@@ -11,9 +11,7 @@ import com.fortickets.concertservice.application.dto.response.GetConcertRes;
 import com.fortickets.concertservice.application.dto.response.GetConcertsRes;
 import com.fortickets.concertservice.application.service.ConcertService;
 import jakarta.validation.Valid;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,7 +22,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -61,7 +58,8 @@ public class ConcertController {
     // 특정 공연 수정
     @PreAuthorize("hasAnyRole('MANAGER', 'SELLER')")
     @PatchMapping("/{concertId}")
-    public CommonResponse<GetConcertRes> updateConcertById(@PathVariable("concertId") Long concertId, @Valid @RequestBody UpdateConcertReq updateConcertReq) {
+    public CommonResponse<GetConcertRes> updateConcertById(@PathVariable("concertId") Long concertId,
+        @Valid @RequestBody UpdateConcertReq updateConcertReq) {
         concertService.updateConcertById(concertId, updateConcertReq);
         return CommonResponse.success(concertService.getConcertById(concertId));
     }
@@ -89,8 +87,8 @@ public class ConcertController {
     // 공연 이름으로 검색
     @GetMapping("/search")
     public CommonResponse<List<GetConcertDetailRes>> searchConcertByName(
-            @RequestParam(required = false, name = "concert-name") String concertName
-    ){
+        @RequestParam(required = false, name = "concert-name") String concertName
+    ) {
         return CommonResponse.success(concertService.searchConcertName(concertName));
     }
 

--- a/application/concert-service/src/main/resources/application.yml
+++ b/application/concert-service/src/main/resources/application.yml
@@ -28,10 +28,10 @@ spring:
         command: down
         timeout: 1m
       file: application/concert-service/docker-compose.yml
-  data:
-    redis:
-      host: localhost
-      port: 6379
+#  data:
+#    redis:
+#      host: localhost
+#      port: 6379
 #      password: "systempass"
 
 server:

--- a/application/user-service/src/main/resources/user-data.sql
+++ b/application/user-service/src/main/resources/user-data.sql
@@ -1,10 +1,9 @@
 insert into users (user_id, nickname, email, phone, password, role, profile_image, is_deleted, created_at, created_by,
-                     updated_at, updated_by, deleted_at, deleted_by)
-
+                   updated_at, updated_by, deleted_at, deleted_by)
 values
-    (1, user1, user1@email.com, 01011111111, $2a$10$CnNR2DDSkw4szC3GkBbeo.wswmyqdcIyDmiNMjcJ/5EVFELCbSbty, 'USER', 'http://user.com/profile1.jpg', false, now(), 1, now(), 1, null, null),
-    (2, user2, user2@email.com, 01022222222, $2a$10$GP3pop4mFpoJfvs2JlOHa.dBoLZp7WmlMpl1omMsD0L5qfMGDVOQy, 'USER', 'http://user.com/profile2.jpg', false, now(), 2, now(), 2, null, null),
-    (3, seller1, seller1@email.com, 01033333333, $2a$10$LKr1CjvIyaGZJShgdTMDruq.mThC61cTcMsDOLaBSuFH73C5zw6I6, 'SELLER', 'http://seller.com/profile3.jpg', false, now(), 3, now(), 3, null, null),
-    (4, seller2, seller2@email.com, 01044444444, $2a$10$BQz5M/WHnj0skq.2vMUxeeFHJkmOgyoHxWDHidkx0NhO4lR9UACj6, 'SELLER', 'http://seller.com/profile4.jpg', false, now(), 4, now(), 4, null, null),
-    (5, master1, master1@email.com, 01055555555, $2a$10$ckAJvYegkzTwJ2ACPsGNoecTy3DBVN4ld84510xlRtZOLYfWs2E12, 'MASTER', 'http://seller.com/profile5.jpg', false, now(), 5, now(), 5, null, null),
-    (6, master2, master2@email.com, 01066666666, $2a$10$SMgy0oe09knNzcdZR4pKq.JwsGzA2y.qmuv4GfyBWSF/RQnlZg5li, 'MASTER', 'http://seller.com/profile6.jpg', false, now(), 6, now(), 6, null, null);
+    (1, 'user1', 'user1@email.com', '01011111111', '$2a$10$CnNR2DDSkw4szC3GkBbeo.wswmyqdcIyDmiNMjcJ/5EVFELCbSbty', 'USER', 'http://user.com/profile1.jpg', false, now(), 1, now(), 1, null, null),
+    (2, 'user2', 'user2@email.com', '01022222222', '$2a$10$GP3pop4mFpoJfvs2JlOHa.dBoLZp7WmlMpl1omMsD0L5qfMGDVOQy', 'USER', 'http://user.com/profile2.jpg', false, now(), 2, now(), 2, null, null),
+    (3, 'seller1', 'seller1@email.com', '01033333333', '$2a$10$LKr1CjvIyaGZJShgdTMDruq.mThC61cTcMsDOLaBSuFH73C5zw6I6', 'SELLER', 'http://seller.com/profile3.jpg', false, now(), 3, now(), 3, null, null),
+    (4, 'seller2', 'seller2@email.com', '01044444444', '$2a$10$BQz5M/WHnj0skq.2vMUxeeFHJkmOgyoHxWDHidkx0NhO4lR9UACj6', 'SELLER', 'http://seller.com/profile4.jpg', false, now(), 4, now(), 4, null, null),
+    (5, 'manager1', 'manager1@email.com', '01055555555', '$2a$10$ckAJvYegkzTwJ2ACPsGNoecTy3DBVN4ld84510xlRtZOLYfWs2E12', 'MANAGER', 'http://seller.com/profile5.jpg', false, now(), 5, now(), 5, null, null),
+    (6, 'manager2', 'manager2@email.com', '01066666666', '$2a$10$SMgy0oe09knNzcdZR4pKq.JwsGzA2y.qmuv4GfyBWSF/RQnlZg5li', 'MANAGER', 'http://seller.com/profile6.jpg', false, now(), 6, now(), 6, null, null);

--- a/component/redis/src/main/java/com/fortickets/redis/RestPage.java
+++ b/component/redis/src/main/java/com/fortickets/redis/RestPage.java
@@ -1,0 +1,28 @@
+package com.fortickets.redis;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * Page<T> 데이터를 캐싱하기 위한 객체. Page<T>를 리턴하는 부분을 감싸서 사용한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"}) // JSON 직렬화 시 무시할 필드를 지정
+public class RestPage<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) // JSON에서 이 클래스의 인스턴스를 생성할 때 사용할 생성자를 지정
+    public RestPage(@JsonProperty("content") List<T> content,
+        @JsonProperty("number") int page,
+        @JsonProperty("size") int size,
+        @JsonProperty("totalElements") long total) {
+        super(content, PageRequest.of(page, size), total);
+    }
+
+    public RestPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/component/redis/src/main/java/com/fortickets/redis/config/CacheConfig.java
+++ b/component/redis/src/main/java/com/fortickets/redis/config/CacheConfig.java
@@ -1,0 +1,49 @@
+package com.fortickets.redis.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) { // Redis 서버와의 연결을 생성하는 데 사용되는 팩토리 클래스
+        // 설정 구성
+        // ObjectMapper : Java 객체를 JSON으로 직렬화하거나 JSON을 Java 객체로 역직렬화하는 데 사용
+        ObjectMapper objectMapper = new ObjectMapper();
+        // registerModule : Java 8의 날짜 및 시간 API (LocalDate, LocalDateTime 등)를 직렬화
+        objectMapper.registerModule(new JavaTimeModule());
+        // activateDefaultTyping : 객체가 직렬화될 때 해당 타입 정보를 JSON에 포함시킬 수 있고, 이를 이용해 역직렬화 할 때 어떤 클래스의 인스턴스인지 확읺한다.
+        objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+        // Redis를 이용해서 Spring Cache를 사용할 때 Redis 관련 설정을 모아두는 클래스
+        RedisCacheConfiguration configuration = RedisCacheConfiguration
+            .defaultCacheConfig()
+            // null을 캐싱 할것인지
+            .disableCachingNullValues()
+            // 기본 캐시 유지 시간 (Time To Live)
+            .entryTtl(Duration.ofSeconds(60))
+            // 캐시를 구분하는 접두사 설정
+            .computePrefixWith(CacheKeyPrefix.simple())
+            // 캐시에 저장할 값을 어떻게 직렬화 / 역직렬화 할것인지
+            .serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper))); // Value 직렬화
+
+        return RedisCacheManager
+            .builder(redisConnectionFactory)
+            .cacheDefaults(configuration)
+            .build();
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #74 

## 📝작업 내용

- 요청이 많고, 변경 사항이 적은 공연 서비스에 Redis Cache 적용

## 💬리뷰 요구사항(선택)

- 좌석 조회에 대해서도 Cache 적용 여부에 대해 고민을 해보았는데
  아무래도 좌석 조회에 경우에는 조회도 많지만 변경 또한 많기 때문에 
  읽기 중심인 Cache의 사용 목적과 맞지않다 생각하여 적용하지 않았습니다.

- ResponseDto에 @Setter를 사용한 이유는
  Dto는 비즈니스 로직을 포함하지 않고 데이터 전송을 위한 용도이기 때문에 사용하였습니다.
  (없으면 Data가 null로 반환돼요...)
