### PR TITLE
Perf/#105 조회 성능 최적화, 리팩토링

### DIFF
--- a/application/concert-service/src/main/java/com/fortickets/concertservice/application/dto/response/GetConcertDetailRes.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/application/dto/response/GetConcertDetailRes.java
@@ -3,7 +3,8 @@ package com.fortickets.concertservice.application.dto.response;
 public record GetConcertDetailRes(
     Long id,
     String concertName,
-    int runtime
+    int runtime,
+    Long price
 ) {
 
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ConcertService.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ConcertService.java
@@ -142,9 +142,9 @@ public class ConcertService {
         return concertMapper.toGetConcertResList(concertList);
     }
 
-    public List<GetConcertRes> getConcertsByIds(List<Long> concertIds) {
+    public List<GetConcertDetailRes> getConcertsByIds(List<Long> concertIds) {
         List<Concert> concertList = concertRepository.findByIdIn(concertIds);
-        return concertMapper.toGetConcertResList(concertList);
+        return concertMapper.toGetConcertDetailResList(concertList);
 
     }
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ConcertService.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ConcertService.java
@@ -131,14 +131,20 @@ public class ConcertService {
     }
 
     // 특정 판매자가 등록한 콘서트 중 해당 문자를 제목에 포함한 콘서트 조회
-    public List<GetConcertDetailRes> searchConcert(Long userId, String concertName) {
+    public List<GetConcertRes> searchConcert(Long userId, String concertName) {
         List<Concert> concertList = concertRepository.findByUserIdAndConcertNameContaining(userId, concertName);
         return concertMapper.toGetConcertResList(concertList);
     }
 
     // 해당 문자를 포함한 콘서트 조회
-    public List<GetConcertDetailRes> searchConcertName(String concertName) {
+    public List<GetConcertRes> searchConcertName(String concertName) {
         List<Concert> concertList = concertRepository.findByConcertNameContaining(concertName);
         return concertMapper.toGetConcertResList(concertList);
+    }
+
+    public List<GetConcertRes> getConcertsByIds(List<Long> concertIds) {
+        List<Concert> concertList = concertRepository.findByIdIn(concertIds);
+        return concertMapper.toGetConcertResList(concertList);
+
     }
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ConcertService.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ConcertService.java
@@ -68,9 +68,7 @@ public class ConcertService {
     public GetConcertRes updateConcertById(Long userId, String role, Long concertId, UpdateConcertReq updateConcertReq) {
         Concert concert = getConcertUtil(concertId);
         // 관리자 또는 본인만 수정 가능
-        if (!concert.getUserId().equals(userId) || !role.equals("MANAGER")) {
-            throw new GlobalException(ErrorCase.NOT_AUTHORIZED);
-        }
+        validateAuthorization(role, userId, concert.getUserId());
         changeConcert(updateConcertReq, concert);
         return concertMapper.toGetConcertRes(concert);
     }
@@ -82,9 +80,7 @@ public class ConcertService {
         Concert concert = getConcertUtil(concertId);
 
         // 관리자 또는 본인만 삭제 가능
-        if (!concert.getUserId().equals(userId) || !role.equals("MANAGER")) {
-            throw new GlobalException(ErrorCase.NOT_AUTHORIZED);
-        }
+        validateAuthorization(role, userId, concert.getUserId());
 
         concert.delete(email);
     }
@@ -146,5 +142,11 @@ public class ConcertService {
         List<Concert> concertList = concertRepository.findByIdIn(concertIds);
         return concertMapper.toGetConcertDetailResList(concertList);
 
+    }
+
+    private void validateAuthorization(String role, Long userId, Long targetUserId) {
+        if (!role.equals("ROLE_MANAGER") && !userId.equals(targetUserId)) {
+            throw new GlobalException(ErrorCase.NOT_AUTHORIZED);
+        }
     }
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ScheduleService.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/application/service/ScheduleService.java
@@ -84,14 +84,13 @@ public class ScheduleService {
         return scheduleMapper.toGetScheduleDetailRes(schedule);
 
     }
+
     // 스케줄 수정
     @Transactional
     public void updateScheduleById(Long getUserId, String role, Long scheduleId, UpdateScheduleReq updateScheduleReq) {
         Schedule schedule = getSchedule(scheduleId);
         Concert concert = schedule.getConcert();
-        if (!concert.getUserId().equals(getUserId) || !role.equals("MANAGER")) {
-            throw new GlobalException(ErrorCase.NOT_AUTHORIZED);
-        }
+        validateAuthorization(role, getUserId, concert.getUserId());
 
         if (updateScheduleReq.concertDate() != null) {
             if (updateScheduleReq.concertDate().isBefore(concert.getStartDate())) {
@@ -113,9 +112,7 @@ public class ScheduleService {
 
         Schedule schedule = getSchedule(scheduleId);
         Concert concert = schedule.getConcert();
-        if (!concert.getUserId().equals(getUserId) || !role.equals("MANAGER")) {
-            throw new GlobalException(ErrorCase.NOT_AUTHORIZED);
-        }
+        validateAuthorization(role, getUserId, concert.getUserId());
         schedule.delete(email);
     }
 
@@ -139,5 +136,11 @@ public class ScheduleService {
     private Stage getStage(Long stageId) {
         return stageRepository.findById(stageId)
             .orElseThrow(() -> new GlobalException(ErrorCase.NOT_EXIST_STAGE));
+    }
+
+    private void validateAuthorization(String role, Long userId, Long targetUserId) {
+        if (!role.equals("ROLE_MANAGER") && !userId.equals(targetUserId)) {
+            throw new GlobalException(ErrorCase.NOT_AUTHORIZED);
+        }
     }
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/domain/mapper/ConcertMapper.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/domain/mapper/ConcertMapper.java
@@ -22,5 +22,5 @@ public interface ConcertMapper {
 
     List<GetConcertDetailRes> toGetConcertDetailResList(List<Concert> concertList);
 
-    List<GetConcertDetailRes> toGetConcertResList(List<Concert> concertList);
+    List<GetConcertRes> toGetConcertResList(List<Concert> concertList);
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/domain/repository/ConcertRepository.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/domain/repository/ConcertRepository.java
@@ -8,4 +8,6 @@ public interface ConcertRepository extends JpaRepository<Concert, Long>, Concert
 
     List<Concert> findByUserId(Long userId);
 
+    List<Concert> findByIdIn(List<Long> concertIds);
+
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/presentation/ConcertController.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/presentation/ConcertController.java
@@ -92,7 +92,7 @@ public class ConcertController {
 
     // 공연 이름으로 검색
     @GetMapping("/search")
-    public CommonResponse<List<GetConcertDetailRes>> searchConcertByName(
+    public CommonResponse<List<GetConcertRes>> searchConcertByName(
         @RequestParam(required = false, name = "concert-name") String concertName
     ) {
         return CommonResponse.success(concertService.searchConcertName(concertName));
@@ -100,14 +100,20 @@ public class ConcertController {
 
     // 특정 판매자의 공연중 해당 문자가 들어간 공연 조회
     @GetMapping("/{userId}/{concertName}/search")
-    List<GetConcertDetailRes> searchConcert(@PathVariable Long userId, @PathVariable String concertName) {
+    List<GetConcertRes> searchConcert(@PathVariable Long userId, @PathVariable String concertName) {
         return concertService.searchConcert(userId, concertName);
     }
 
     // 해당 문자가 들어간 공연 조회
     @GetMapping("/{concertName}/search")
-    List<GetConcertDetailRes> searchConcertName(@PathVariable String concertName) {
+    List<GetConcertRes> searchConcertName(@PathVariable String concertName) {
         return concertService.searchConcertName(concertName);
+    }
+
+    // 공연 ID List로 공연 정보 조회
+    @PostMapping("/list")
+    List<GetConcertRes> getConcertsByIds(@RequestBody List<Long> concertIds) {
+        return concertService.getConcertsByIds(concertIds);
     }
 
 }

--- a/application/concert-service/src/main/java/com/fortickets/concertservice/presentation/ConcertController.java
+++ b/application/concert-service/src/main/java/com/fortickets/concertservice/presentation/ConcertController.java
@@ -112,7 +112,7 @@ public class ConcertController {
 
     // 공연 ID List로 공연 정보 조회
     @PostMapping("/list")
-    List<GetConcertRes> getConcertsByIds(@RequestBody List<Long> concertIds) {
+    List<GetConcertDetailRes> getConcertsByIds(@RequestBody List<Long> concertIds) {
         return concertService.getConcertsByIds(concertIds);
     }
 

--- a/application/concert-service/src/main/resources/application.yml
+++ b/application/concert-service/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
       file: application/concert-service/docker-compose.yml
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 #      password: "systempass"
 

--- a/application/concert-service/src/main/resources/application.yml
+++ b/application/concert-service/src/main/resources/application.yml
@@ -13,8 +13,8 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        show_sql: false # sql 로깅
-        format_sql: true # SQL 문 정렬하여 출력
+        show_sql: true # sql 로깅
+        format_sql: false # SQL 문 정렬하여 출력
         highlight_sql: true # SQL 문 색 부여
   # docker compose lifecycle 설정
   docker:

--- a/application/gateway-service/src/main/resources/application.yml
+++ b/application/gateway-service/src/main/resources/application.yml
@@ -32,7 +32,7 @@ spring:
           filters:
             - RewritePath=/order-service/(?<segment>.*), /${segment}
   kafka:
-    bootstrap-servers: kafka:29092
+    bootstrap-servers: localhost:9092
 
 server:
   port: 12011

--- a/application/order-service/src/main/java/com/fortickets/orderservice/application/client/ConcertClient.java
+++ b/application/order-service/src/main/java/com/fortickets/orderservice/application/client/ConcertClient.java
@@ -32,4 +32,7 @@ public interface ConcertClient {
     // userId로 Concert 정보 조회 o
     @GetMapping("/concerts/{userId}/seller")
     List<GetConcertRes> getConcertBySeller(@PathVariable(value = "userId") Long userId);
+
+    List<GetConcertRes> getConcertsByIds(List<Long> concertIds);
 }
+

--- a/application/order-service/src/main/java/com/fortickets/orderservice/application/client/ConcertClient.java
+++ b/application/order-service/src/main/java/com/fortickets/orderservice/application/client/ConcertClient.java
@@ -8,6 +8,8 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "concert-service", configuration = FeignClientConfig.class)
 @Component
@@ -33,6 +35,7 @@ public interface ConcertClient {
     @GetMapping("/concerts/{userId}/seller")
     List<GetConcertRes> getConcertBySeller(@PathVariable(value = "userId") Long userId);
 
-    List<GetConcertRes> getConcertsByIds(List<Long> concertIds);
+    @PostMapping("/concerts/list")
+    List<GetConcertRes> getConcertsByIds(@RequestBody List<Long> concertIds);
 }
 

--- a/application/order-service/src/main/java/com/fortickets/orderservice/application/service/PaymentService.java
+++ b/application/order-service/src/main/java/com/fortickets/orderservice/application/service/PaymentService.java
@@ -8,6 +8,7 @@ import com.fortickets.orderservice.application.client.UserClient;
 import com.fortickets.orderservice.application.dto.request.CreatePaymentReq;
 import com.fortickets.orderservice.application.dto.request.RequestPaymentReq;
 import com.fortickets.orderservice.application.dto.response.CreatePaymentRes;
+import com.fortickets.orderservice.application.dto.response.GetConcertRes;
 import com.fortickets.orderservice.application.dto.response.GetPaymentDetailRes;
 import com.fortickets.orderservice.application.dto.response.GetPaymentRes;
 import com.fortickets.orderservice.application.dto.response.GetUserRes;
@@ -17,8 +18,11 @@ import com.fortickets.orderservice.domain.mapper.PaymentMapper;
 import com.fortickets.orderservice.domain.repository.BookingRepository;
 import com.fortickets.orderservice.domain.repository.PaymentRepository;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -42,6 +46,7 @@ public class PaymentService {
     public CreatePaymentRes createPayment(CreatePaymentReq createPaymentReq) {
         // 결제 생성
         Payment payment = paymentMapper.toEntity(createPaymentReq);
+        // 결제 대기 상태로 세팅
         payment.waiting();
         paymentRepository.save(payment);
 
@@ -61,18 +66,23 @@ public class PaymentService {
 
     // 결제 내역 전체 조회 (Manager)
     public Page<GetPaymentRes> getPayments(String nickname, Pageable pageable) {
-        List<GetUserRes> userResList = new ArrayList<>();
-        Page<Payment> payments = null;
-        if (nickname != null) {
-            userResList = userClient.searchNickname(nickname);
-            payments = paymentRepository.findByUserIdIn(userResList.stream().map(GetUserRes::userId).toList(), pageable);
-        } else {
-            payments = paymentRepository.findAll(pageable);
-        }
-        List<GetPaymentRes> getPaymentResList = payments.getContent().stream().map(payment -> {
-            var getConcertRes = concertClient.getConcert(payment.getConcertId());
-            return paymentMapper.toGetPaymentUser(payment, getConcertRes);
-        }).toList();
+        // 주어진 닉네임에 따른 사용자 ID 리스트
+        List<Long> userIds = getUserIdsByNickname(nickname);
+        // 사용자 ID 리스트를 기준으로 결제 조회
+        Page<Payment> payments = findPaymentsByUserIds(userIds, pageable);
+
+        // 콘서트 ID 리스트를 생성
+        List<Long> concertIds = payments.getContent().stream()
+            .map(Payment::getConcertId)
+            .distinct() // 중복된 콘서트 ID 제거
+            .toList();
+
+        // 콘서트 정보를 일괄 조회
+        Map<Long, GetConcertRes> concertMap = fetchConcertsByIds(concertIds);
+
+        // 결제를 GetPaymentRes 객체로 매핑
+        List<GetPaymentRes> getPaymentResList = mapPaymentsToResponse(payments, concertMap);
+
         return new PageImpl<>(getPaymentResList, pageable, payments.getTotalElements());
     }
 
@@ -83,18 +93,23 @@ public class PaymentService {
                 throw new GlobalException(ErrorCase.NOT_AUTHORIZED);
             }
         }
-        List<GetUserRes> userResList = new ArrayList<>();
-        Page<Payment> payments = null;
-        if (nickname != null) {
-            userResList = userClient.searchNickname(nickname);
-            payments = paymentRepository.findByUserIdIn(userResList.stream().map(GetUserRes::userId).toList(), pageable);
-        } else {
-            payments = paymentRepository.findAll(pageable);
-        }
-        List<GetPaymentRes> getPaymentResList = payments.getContent().stream().map(payment -> {
-            var getConcertRes = concertClient.getConcert(payment.getConcertId());
-            return paymentMapper.toGetPaymentUser(payment, getConcertRes);
-        }).toList();
+        // 주어진 닉네임에 따른 사용자 ID 리스트
+        List<Long> userIds = getUserIdsByNickname(nickname);
+        // 사용자 ID 리스트를 기준으로 결제 조회
+        Page<Payment> payments = findPaymentsByUserIds(userIds, pageable);
+
+        // 콘서트 ID 리스트를 생성
+        List<Long> concertIds = payments.getContent().stream()
+            .map(Payment::getConcertId)
+            .distinct() // 중복된 콘서트 ID 제거
+            .toList();
+
+        // 콘서트 정보를 일괄 조회
+        Map<Long, GetConcertRes> concertMap = fetchConcertsByIds(concertIds);
+
+        // 결제를 GetPaymentRes 객체로 매핑
+        List<GetPaymentRes> getPaymentResList = mapPaymentsToResponse(payments, concertMap);
+
         return new PageImpl<>(getPaymentResList, pageable, payments.getTotalElements());
     }
 
@@ -197,4 +212,51 @@ public class PaymentService {
         });
     }
 
+
+    /**
+     * 주어진 닉네임으로 사용자 ID 리스트를 가져옵니다. 닉네임이 null인 경우 빈 리스트를 반환합니다.
+     */
+    private List<Long> getUserIdsByNickname(String nickname) {
+        if (nickname == null) {
+            return Collections.emptyList(); // 닉네임이 null일 경우 빈 리스트 반환
+        }
+        // 닉네임으로 사용자 정보를 검색하여 사용자 ID 리스트를 반환합니다.
+        List<GetUserRes> userResList = userClient.searchNickname(nickname);
+        return userResList.stream().map(GetUserRes::userId).toList();
+    }
+
+    private Page<Payment> findPaymentsByUserIds(List<Long> userIds, Pageable pageable) {
+        if (userIds == null || userIds.isEmpty()) {
+            // userIds가 null이거나 비어있으면 모든 결제를 반환합니다.
+            return paymentRepository.findAll(pageable);
+        }
+        // userIds가 존재하는 경우, 해당 사용자 ID로 결제를 반환합니다.
+        return paymentRepository.findByUserIdIn(userIds, pageable);
+    }
+
+    /**
+     * 주어진 콘서트 ID 리스트로 콘서트 정보를 일괄 조회하여 Map으로 반환합니다.
+     */
+    private Map<Long, GetConcertRes> fetchConcertsByIds(List<Long> concertIds) {
+        // 콘서트 ID가 없으면 빈 맵 반환
+        if (concertIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        // 모든 콘서트 정보를 한 번에 조회합니다.
+        return concertClient.getConcertsByIds(concertIds).stream()
+            .collect(Collectors.toMap(GetConcertRes::id, Function.identity()));
+    }
+
+    /**
+     * 결제 리스트를 GetPaymentRes 객체로 매핑
+     */
+    private List<GetPaymentRes> mapPaymentsToResponse(Page<Payment> payments, Map<Long, GetConcertRes> concertMap) {
+        return payments.getContent().stream()
+            .map(payment -> {
+                // 미리 조회한 콘서트 정보를 맵에서 가져오기
+                GetConcertRes getConcertRes = concertMap.get(payment.getConcertId());
+                return paymentMapper.toGetPaymentUser(payment, getConcertRes);
+            })
+            .toList();
+    }
 }

--- a/application/order-service/src/main/java/com/fortickets/orderservice/application/service/PaymentService.java
+++ b/application/order-service/src/main/java/com/fortickets/orderservice/application/service/PaymentService.java
@@ -214,7 +214,7 @@ public class PaymentService {
 
 
     /**
-     * 주어진 닉네임으로 사용자 ID 리스트를 가져옵니다. 닉네임이 null인 경우 빈 리스트를 반환합니다.
+     * 주어진 닉네임으로 사용자 ID 리스트 가져오기. 닉네임이 null인 경우 빈 리스트를 반환
      */
     private List<Long> getUserIdsByNickname(String nickname) {
         if (nickname == null) {
@@ -235,7 +235,7 @@ public class PaymentService {
     }
 
     /**
-     * 주어진 콘서트 ID 리스트로 콘서트 정보를 일괄 조회하여 Map으로 반환합니다.
+     * 주어진 콘서트 ID 리스트로 콘서트 정보를 일괄 조회하여 Map으로 반환
      */
     private Map<Long, GetConcertRes> fetchConcertsByIds(List<Long> concertIds) {
         // 콘서트 ID가 없으면 빈 맵 반환

--- a/application/order-service/src/main/java/com/fortickets/orderservice/application/service/PaymentService.java
+++ b/application/order-service/src/main/java/com/fortickets/orderservice/application/service/PaymentService.java
@@ -220,9 +220,7 @@ public class PaymentService {
     }
 
 
-    /**
-     * 주어진 닉네임으로 사용자 ID 리스트 가져오기. 닉네임이 null인 경우 빈 리스트를 반환
-     */
+    // 주어진 닉네임으로 사용자 ID 리스트 가져오기. 닉네임이 null인 경우 빈 리스트를 반환
     private List<Long> getUserIdsByNickname(String nickname) {
         if (nickname == null) {
             return Collections.emptyList(); // 닉네임이 null일 경우 빈 리스트 반환
@@ -232,6 +230,7 @@ public class PaymentService {
         return userResList.stream().map(GetUserRes::userId).toList();
     }
 
+    // userIds가 존재하는 경우, 해당 사용자 ID로 결제를 반환
     private Page<Payment> findPaymentsByUserIds(List<Long> userIds, Pageable pageable) {
         if (userIds == null || userIds.isEmpty()) {
             // userIds가 null이거나 비어있으면 모든 결제를 반환합니다.
@@ -241,9 +240,7 @@ public class PaymentService {
         return paymentRepository.findByUserIdIn(userIds, pageable);
     }
 
-    /**
-     * 주어진 콘서트 ID 리스트로 콘서트 정보를 일괄 조회하여 Map으로 반환
-     */
+    //  주어진 콘서트 ID 리스트로 콘서트 정보를 일괄 조회하여 Map으로 반환
     private Map<Long, GetConcertRes> fetchConcertsByIds(List<Long> concertIds) {
         // 콘서트 ID가 없으면 빈 맵 반환
         if (concertIds.isEmpty()) {
@@ -254,9 +251,7 @@ public class PaymentService {
             .collect(Collectors.toMap(GetConcertRes::id, Function.identity()));
     }
 
-    /**
-     * 결제 리스트를 GetPaymentRes 객체로 매핑
-     */
+    // 결제 리스트를 GetPaymentRes 객체로 매핑
     private List<GetPaymentRes> mapPaymentsToResponse(Page<Payment> payments, Map<Long, GetConcertRes> concertMap) {
         return payments.getContent().stream()
             .map(payment -> {

--- a/application/order-service/src/main/java/com/fortickets/orderservice/infrastructure/scheduler/OrderScheduler.java
+++ b/application/order-service/src/main/java/com/fortickets/orderservice/infrastructure/scheduler/OrderScheduler.java
@@ -5,7 +5,6 @@ import com.fortickets.orderservice.domain.repository.BookingRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +15,7 @@ public class OrderScheduler {
     private final BookingRepository bookingRepository;
 
     // 10분마다 한번씩 실행
-    @Scheduled(cron = "0 0/10 * * * * ")
+//    @Scheduled(cron = "0 0/10 * * * * ")
     @Transactional
     @Async
     public void cancelBooking() {

--- a/application/order-service/src/main/resources/application.yml
+++ b/application/order-service/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     properties:
       hibernate:
         show_sql: true # sql 로깅
-        format_sql: true # SQL 문 정렬하여 출력
+        format_sql: false # SQL 문 정렬하여 출력
         highlight_sql: true # SQL 문 색 부여
   docker:
     compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,6 @@ services:
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
-    platform: linux/amd64
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #105 

## 📝작업 내용

> local 실행 가능하도록 수정
결제 내역 조회 API 쿼리 최적화 
(결제 내역별로 concert 정보를 가져오는 로직에서 결제 내역에서 concertId를 한번에 조회해오는 로직으로 변경)
권한 검증 메서드 분리 (공통 메서드)

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/11d5671b-ad74-4420-9fae-f04f78362efd)
![image](https://github.com/user-attachments/assets/826bbaaa-94f7-44c2-9750-dfd1b43817a4)
